### PR TITLE
Make timing be a pure function

### DIFF
--- a/App.elm
+++ b/App.elm
@@ -2,21 +2,26 @@ module App where
 
 import Graphics.Element exposing (..)
 import Graphics.Input exposing (..)
+import ScaleTemplates exposing (..)
 import Time exposing (..)
 
 import Types exposing(..)
 import Chords
 
-type Page = About | ChordLibraryPage ChordChart
+type Page = About
+          | ChordLibraryPage ChordChart
+          | PlayAlong Note ChordProgression
 
 pageBox : Signal.Mailbox Page
 pageBox =
-    Signal.mailbox (ChordLibraryPage Chords.a)
+    Signal.mailbox (PlayAlong A chordProgression)
 
 pageSignal : Signal (Time, Page)
 pageSignal = timestamp pageBox.signal
 
 embedPageTemplate : Element -> Element
 embedPageTemplate pageTemplate =
-    let pageChangeBtn = button (Signal.message pageBox.address <| ChordLibraryPage Chords.a) "Push it baby"
+    let pageChangeBtn = flip button "Push it baby"
+                     << Signal.message pageBox.address
+                     <| PlayAlong A chordProgression
     in flow down [pageTemplate, pageChangeBtn]

--- a/App.elm
+++ b/App.elm
@@ -2,6 +2,7 @@ module App where
 
 import Graphics.Element exposing (..)
 import Graphics.Input exposing (..)
+import Time exposing (..)
 
 import Types exposing(..)
 import Chords
@@ -11,6 +12,9 @@ type Page = About | ChordLibraryPage ChordChart
 pageBox : Signal.Mailbox Page
 pageBox =
     Signal.mailbox (ChordLibraryPage Chords.a)
+
+pageSignal : Signal (Time, Page)
+pageSignal = timestamp pageBox.signal
 
 embedPageTemplate : Element -> Element
 embedPageTemplate pageTemplate =

--- a/ChordLibraryPage.elm
+++ b/ChordLibraryPage.elm
@@ -14,13 +14,12 @@ import List exposing (map)
 chordList : List ChordButton.Model
 chordList = toList Chords.knownChords
 
-view : ChordChart -> (Int, Int) -> Signal.Address App.Page -> Element
-view chord viewport address =
+view : Viewport -> ChordChart -> Signal.Address App.Page -> Element
+view viewport chord address =
     let width = fst viewport
-        height = snd viewport
         chordButtonViews = flow right (map (ChordButton.view address) chordList)
         chordButtonListView = container width 200 middle chordButtonViews
         activeChordView = collage width 200 [fretboard, drawChordChart chord]
         layout = flow down [activeChordView, chordButtonListView]
-    in [toForm layout] |> collage width height
+    in [toForm layout] |> uncurry collage viewport
 

--- a/ChordLibraryPage.elm
+++ b/ChordLibraryPage.elm
@@ -14,11 +14,13 @@ import List exposing (map)
 chordList : List ChordButton.Model
 chordList = toList Chords.knownChords
 
-view : ChordChart -> Viewport a -> Signal.Address App.Page -> Element
+view : ChordChart -> (Int, Int) -> Signal.Address App.Page -> Element
 view chord viewport address =
-    let chordButtonViews = flow right (map (ChordButton.view address) chordList)
-        chordButtonListView = container viewport.width 200 middle chordButtonViews
-        activeChordView = collage viewport.width 200 [fretboard, drawChordChart chord]
+    let width = fst viewport
+        height = snd viewport
+        chordButtonViews = flow right (map (ChordButton.view address) chordList)
+        chordButtonListView = container width 200 middle chordButtonViews
+        activeChordView = collage width 200 [fretboard, drawChordChart chord]
         layout = flow down [activeChordView, chordButtonListView]
-    in [toForm layout] |> collage viewport.width viewport.height
+    in [toForm layout] |> collage width height
 

--- a/Main.elm
+++ b/Main.elm
@@ -13,9 +13,9 @@ main: Signal Element
 main = Signal.map App.embedPageTemplate
     <| Signal.map3 router pageSignal Timing.now dimensions
 
-router : (Time, App.Page) -> Time -> (Int, Int) -> Element
-router (start, page) now world =
+router : (Time, App.Page) -> Time -> Viewport -> Element
+router (start, page) now viewport =
     case page of
-        App.ChordLibraryPage chord -> ChordLibraryPage.view chord world pageBox.address
+        App.ChordLibraryPage chord -> ChordLibraryPage.view viewport chord pageBox.address
         App.About -> show "Ariel and Sandy are ridiculously sexy beasts. haha hahaa" -- About.view
 

--- a/Main.elm
+++ b/Main.elm
@@ -1,33 +1,21 @@
 module Main where
 
-import App exposing (pageBox)
+import App exposing (pageSignal, pageBox)
 import Timing
 import Types exposing (..)
 import ChordLibraryPage
 
+import Time exposing (Time)
 import Graphics.Element exposing (..)
 import Window exposing (dimensions)
 
 main: Signal Element
 main = Signal.map App.embedPageTemplate
-    <| Signal.map2 router pageBox.signal worldSignal
+    <| Signal.map3 router pageSignal Timing.now dimensions
 
-router : App.Page -> WorldModel -> Element
-router page world =
+router : (Time, App.Page) -> Time -> (Int, Int) -> Element
+router (start, page) now world =
     case page of
         App.ChordLibraryPage chord -> ChordLibraryPage.view chord world pageBox.address
         App.About -> show "Ariel and Sandy are ridiculously sexy beasts. haha hahaa" -- About.view
-
-worldSignal : Signal WorldModel
-worldSignal =
-    let f (w, h) timing =
-        { semiquaver = timing.semiquaver
-        , quaver     = timing.quaver
-        , crotchet   = timing.crotchet
-        , minim      = timing.minim
-        , semibreve  = timing.semibreve
-        , width      = w
-        , height     = h
-        }
-    in Signal.map2 f dimensions Timing.timingSignal
 

--- a/Main.elm
+++ b/Main.elm
@@ -1,9 +1,10 @@
 module Main where
 
-import App exposing (pageSignal, pageBox)
+import App exposing (Page (..), pageSignal, pageBox)
 import Timing
 import Types exposing (..)
 import ChordLibraryPage
+import Pages.PlayAlong
 
 import Time exposing (Time)
 import Graphics.Element exposing (..)
@@ -13,9 +14,17 @@ main: Signal Element
 main = Signal.map App.embedPageTemplate
     <| Signal.map3 router pageSignal Timing.now dimensions
 
-router : (Time, App.Page) -> Time -> Viewport -> Element
+router : (Time, Page) -> Time -> Viewport -> Element
 router (start, page) now viewport =
     case page of
-        App.ChordLibraryPage chord -> ChordLibraryPage.view viewport chord pageBox.address
-        App.About -> show "Ariel and Sandy are ridiculously sexy beasts. haha hahaa" -- About.view
+        App.ChordLibraryPage chord ->
+            ChordLibraryPage.view viewport chord pageBox.address
+        About ->
+            show "Ariel and Sandy are ridiculously sexy beasts. haha hahaa" -- About.view
+        PlayAlong note prog ->
+            Pages.PlayAlong.view
+                viewport
+                (Timing.computeTiming 120 start now)
+                note
+                prog
 

--- a/Pages/PlayAlong.elm
+++ b/Pages/PlayAlong.elm
@@ -1,0 +1,61 @@
+module Pages.PlayAlong where
+
+import List
+import Types exposing (..)
+import ChordDrawing exposing (drawChordChart, fretboard)
+import Graphics.Element exposing (..)
+import Timing exposing (..)
+
+import Graphics.Collage exposing (Form (..), collage, toForm, text, filled, moveX, moveY, rect, circle, group, solid, outlined)
+import Color exposing (grey, black, white, green, red)
+
+barWidth = 150
+barHeight = 100
+
+barsNumX = 4
+barsNumY = 2
+
+semiquaverOffset : Int -> Float
+semiquaverOffset sq = toFloat sq * barWidth / 16 - barWidth / 32
+
+bars : Form
+bars =
+    let width = barWidth * barsNumX
+        height = barHeight * barsNumY
+    in [ rect 1 height |> filled black |> moveX -barWidth
+       , rect 1 height |> filled black |> moveX  barWidth
+       , rect 1 height |> filled black
+       , rect width 1 |> filled black
+       , rhythmDots
+       ] |> group
+
+rhythmDots : Form
+rhythmDots =
+    let dot mm sq = circle 3
+                 |> outlined (solid black)
+                 |> moveToTime mm (sq - 1)
+    in group
+          << List.concat
+          << flip   List.map          [0 .. barsNumX * barsNumY - 1]
+          <| \mm -> List.map (dot mm) [4, 8, 12, 16]
+
+
+
+moveToTime : Int -> Int -> Form -> Form
+moveToTime mm sq = moveX (-barWidth * barsNumX / 2)
+                >> moveY (barHeight / 2)
+                >> moveX (semiquaverOffset sq)
+                >> moveX (toFloat <| mm % barsNumX * barWidth)
+                >> moveY (toFloat <| (mm // barsNumX) % barsNumY * -barHeight)
+
+scrubber : Timing -> Form
+scrubber time = rect 2 barHeight
+             |> filled red
+             |> moveToTime time.measure time.semiquaver
+
+
+
+view : Viewport -> Timing -> Note -> ChordProgression -> Element
+view viewport time note prog =
+    collage 600 200 [ scrubber time, bars ]
+

--- a/Timing.elm
+++ b/Timing.elm
@@ -18,8 +18,8 @@ now = every millisecond
 
 computeTiming : Int -> Time -> Time -> Timing
 computeTiming bpm start now =
-    let sqps = 15000 // bpm
-        dt   = round <| now - start
+    let sqps = 15000 / toFloat bpm
+        dt   = round <| (now - start) / sqps
 
         sq =  dt       % 16
         q  = (dt // 2) % 8

--- a/Timing.elm
+++ b/Timing.elm
@@ -5,21 +5,34 @@ import Graphics.Input.Field exposing (Content, noContent)
 import Time exposing (..)
 import ParseInt exposing (parseInt)
 
-type alias Timing a =
-    { a
-    | semiquaver : Int
+type alias Timing =
+    { semiquaver : Int
     , quaver     : Int
     , crotchet   : Int
     , minim      : Int
-    , semibreve  : Int
+    , measure    : Int
     }
 
-clockSignal : Signal Float
-clockSignal =
-    let dropOldTime newTime (oldTime, _) = (newTime, oldTime)
-        timeDelta (newTime, oldTime)     = newTime - oldTime
-        timePairSignal = every millisecond |> Signal.foldp dropOldTime (1454745969,0)
-    in Signal.map timeDelta timePairSignal
+now : Signal Time
+now = every millisecond
+
+computeTiming : Time -> Time -> Timing
+computeTiming start now =
+    let bpm = 120
+        sqps = 15000 // bpm
+        dt = round <| now - start
+
+        sq =  dt       % 16
+        q  = (dt // 2) % 8
+        c  = (dt // 4) % 4
+        m  = (dt // 8) % 2
+        mm =  dt // 16
+    in { semiquaver = sq
+       , quaver = q
+       , crotchet = c
+       , minim = m
+       , measure = mm
+       }
 
 bpmMailbox : Signal.Mailbox Content
 bpmMailbox = Signal.mailbox noContent
@@ -30,45 +43,4 @@ bpmSignal = let onBpmChange s = (case parseInt s.string of
                 Err _     -> 1
             )
             in Signal.map onBpmChange bpmMailbox.signal
-
-sqps : Int
-sqps =
-    let bpm = 120
-    in 15000 // bpm
-
-foldEvery2 : Int -> Signal Int -> Signal Int
-foldEvery2 max = flip foldp 0 (\i -> flip (%) max << (+) (1 - i % 2))
-              << dropRepeats
-
-semiquaverSignal : Signal Int
-semiquaverSignal = foldp (always <| (+) 1 >> flip (%) 16) 0
-                << every <| toFloat sqps
-
-quaverSignal : Signal Int
-quaverSignal = foldEvery2 8 semiquaverSignal
-
-crotchetSignal : Signal Int
-crotchetSignal = foldEvery2 4 quaverSignal
-
-minimSignal: Signal Int
-minimSignal = foldEvery2 2 crotchetSignal
-
-semibreveSignal : Signal Int
-semibreveSignal = foldEvery2 16 minimSignal
-
-timingSignal : Signal (Timing {})
-timingSignal =
-    let f a b c d e =
-        { semiquaver = a
-        , quaver     = b
-        , crotchet   = c
-        , minim      = d
-        , semibreve  = e
-        }
-    in Signal.map5 f
-           semiquaverSignal
-           quaverSignal
-           crotchetSignal
-           minimSignal
-           semibreveSignal
 

--- a/Timing.elm
+++ b/Timing.elm
@@ -16,11 +16,10 @@ type alias Timing =
 now : Signal Time
 now = every millisecond
 
-computeTiming : Time -> Time -> Timing
-computeTiming start now =
-    let bpm = 120
-        sqps = 15000 // bpm
-        dt = round <| now - start
+computeTiming : Int -> Time -> Time -> Timing
+computeTiming bpm start now =
+    let sqps = 15000 // bpm
+        dt   = round <| now - start
 
         sq =  dt       % 16
         q  = (dt // 2) % 8
@@ -28,10 +27,10 @@ computeTiming start now =
         m  = (dt // 8) % 2
         mm =  dt // 16
     in { semiquaver = sq
-       , quaver = q
-       , crotchet = c
-       , minim = m
-       , measure = mm
+       , quaver     = q
+       , crotchet   = c
+       , minim      = m
+       , measure    = mm
        }
 
 bpmMailbox : Signal.Mailbox Content

--- a/Types.elm
+++ b/Types.elm
@@ -3,22 +3,6 @@ module Types where
 import Array exposing (Array)
 import Typeclasses
 
-type alias WorldModel =
-    { semiquaver : Int
-    , quaver     : Int
-    , crotchet   : Int
-    , minim      : Int
-    , semibreve  : Int
-    , width      : Int
-    , height     : Int
-    }
-
-type alias Viewport a =
-    { a
-    | width  : Int
-    , height : Int
-    }
-
 type alias GString = Int
 
 type alias Fret = Int

--- a/Types.elm
+++ b/Types.elm
@@ -3,6 +3,8 @@ module Types where
 import Array exposing (Array)
 import Typeclasses
 
+type alias Viewport = (Int, Int)
+
 type alias GString = Int
 
 type alias Fret = Int


### PR DESCRIPTION
Added `computeTiming : Int -> Time -> Time -> Timing`

We were going to do this originally, but couldn't figure out how to get the starting time. I wrapped the page signal with a timestamp, so we know when it changes, and compute all of our timing relative to that.  In the future, we'll explicitly make it part of the model so we can choose which actions should reset that, but baby steps first.

Doing it like this means call sites can compute their own timing, and so it doesn't need to be part of the global model anymore. Since that means the only global model is just the viewport, which we were just wrapping into our own model, I removed that concept entirely. Things are cleaner. It's nice. Progress has been made.
