### PR TITLE
Tempo-job button. Makes tempos jobbier.

### DIFF
--- a/App.elm
+++ b/App.elm
@@ -9,11 +9,11 @@ import Types exposing(..)
 
 type Page = About
           | ChordLibrary Chord
-          | PlayAlong Note ChordProgression
+          | PlayAlong Note ChordProgression Int
 
 pageBox : Signal.Mailbox Page
 pageBox =
-    Signal.mailbox (PlayAlong C chordProgression)
+    Signal.mailbox (PlayAlong C chordProgression 120)
 
 pageSignal : Signal (Time, Page)
 pageSignal = timestamp pageBox.signal
@@ -22,7 +22,7 @@ embedPageTemplate : Element -> Element
 embedPageTemplate pageTemplate =
     let playAlongBtn = flip button "Play Along"
                      << Signal.message pageBox.address
-                     <| PlayAlong G chordProgression
+                     <| PlayAlong G chordProgression 120
         chordLibBtn = flip button "Chord Library"
                       << Signal.message pageBox.address
                       <| ChordLibrary (C, Maj)

--- a/Components/TempoSelector.elm
+++ b/Components/TempoSelector.elm
@@ -1,0 +1,12 @@
+module Components.TempoSelector where
+
+import Graphics.Input exposing (..)
+import Graphics.Element exposing (..)
+
+import App exposing (pageBox, Page (..))
+import Types exposing (..)
+import ScaleTemplates exposing (..)
+
+tempoSelector : (Int -> a) -> Signal.Address a -> Int -> Element
+tempoSelector f address bpm = 
+    button (Signal.message address <| f <| bpm*2) "Tempo-job"

--- a/Main.elm
+++ b/Main.elm
@@ -21,10 +21,10 @@ router (start, page) now viewport =
             Pages.ChordLibrary.view viewport chord pageBox.address
         About ->
             show "Ariel and Sandy are ridiculously sexy beasts. haha hahaa" -- About.view
-        PlayAlong note prog ->
+        PlayAlong note prog bpm ->
             Pages.PlayAlong.view
                 viewport
-                (Timing.computeTiming 120 start now)
+                (Timing.computeTiming bpm start now)
                 note
                 prog
 

--- a/Pages/PlayAlong.elm
+++ b/Pages/PlayAlong.elm
@@ -4,6 +4,7 @@ import App exposing (pageBox)
 import Chords
 import Components.ChordChart exposing (chordChart)
 import Components.KeySelector exposing (keySelector)
+import Components.TempoSelector exposing (tempoSelector)
 import KeyUtils exposing (nameOfRelativeChord, scaleNote)
 import ScaleTemplates exposing (getScaleTemplate)
 import Timing exposing (Timing)
@@ -52,7 +53,8 @@ view viewport time tonic prog =
                 |> moveX (barsNumX / 2 * barWidth)
                 |> moveX 100
             ]
-        , keySelector (flip App.PlayAlong prog) pageBox.address
+        , keySelector (\note -> App.PlayAlong note prog time.bpm) pageBox.address
+        , tempoSelector (\bpm -> App.PlayAlong tonic prog bpm) pageBox.address time.bpm
         ]
 
 scrubber : Timing -> Form

--- a/Timing.elm
+++ b/Timing.elm
@@ -11,6 +11,7 @@ type alias Timing =
     , crotchet   : Int
     , minim      : Int
     , measure    : Int
+    , bpm        : Int
     }
 
 now : Signal Time
@@ -31,6 +32,7 @@ computeTiming bpm start now =
        , crotchet   = c
        , minim      = m
        , measure    = mm
+       , bpm        = bpm
        }
 
 bpmMailbox : Signal.Mailbox Content


### PR DESCRIPTION
Tempo Component doubles tempo with every click.
Tempo (bpm) now stored with Timing information
Tempo preserved across PlayAlong pages.
